### PR TITLE
expand credentials file path containing tilde (~)

### DIFF
--- a/src/aws-credentials/provider/shared_credential_file_provider.cr
+++ b/src/aws-credentials/provider/shared_credential_file_provider.cr
@@ -10,9 +10,10 @@ module Aws::Credentials
     @config : Hash(String, String)? = nil
 
     def initialize(
-      @file_path : String = ENV["AWS_SHARED_CREDENTIALS_FILE"]?.try { |e|
-        File.expand_path e
-      } || File.expand_path("~/.aws/credentials"),
+      @file_path : String = File.expand_path(
+        ENV.fetch("AWS_SHARED_CREDENTIALS_FILE", "~/.aws/credentials"),
+        home: true
+      ),
       @profile : String = "default"
     )
     end


### PR DESCRIPTION
Hi,

Thank you for maintaining this crystal library.
When I tried using it to get hold of credentials from the shared credentials file at `~/.aws/credentials` I noted that it didn't properly expanded the tilde (~) to the fully qualified path to the file. I think there was a missing parameter `home` to the `File.expand_path` method.

This PR aims to remedy that, and I hope that you find it useful. :)